### PR TITLE
Add edit button with help note to embedded checklist

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -65,6 +65,13 @@ class filter_checklist extends moodle_text_filter {
 
                 $output = "<div id='filter_checklist'>";
                 $output .= $checklist->view(true);
+                if (has_capability('mod/checklist:edit', $context) && get_config('filter_checklist', 'edit_checklist_from_filter')) {
+                    $editlink = new moodle_url('/mod/checklist/edit.php', ['id' => $cm->id]);
+                    $output .= $this->filter_checklist_get_button($checklistname, $editlink);
+                    if (!empty($helpmessage = get_config('filter_checklist', 'edit_button_help_message'))) {
+                        $output .= "<p>" . $helpmessage . "</p>";
+                    }
+                }
                 $output .= "</div>";
 
                 $text = preg_replace('/\{checklist:' . preg_quote($cm->name, '/') . '\}/isuU', $output, $text) ?? $text;
@@ -72,6 +79,10 @@ class filter_checklist extends moodle_text_filter {
         }
 
         return $text;
+    }
+
+    private function filter_checklist_get_button($name, $link) {
+        return '<a href="' . $link->out() . '" class="btn btn-primary filter-checklist-edit" target="_blank">' . get_string('edit') . ' <i>' . $name . '</i></a>';
     }
 }
 

--- a/lang/en/filter_checklist.php
+++ b/lang/en/filter_checklist.php
@@ -23,3 +23,7 @@
 
 $string['filtername'] = 'Checklist';
 $string['privacy:metadata'] = 'The filter checklist plugin does not store any personal data.';
+$string['edit_checklist_from_filter'] = 'Allow checklist edit from filter';
+$string['edit_checklist_from_filter_desc'] = 'Adds a button to the checklist filter output to edit the checklist.';
+$string['edit_button_help_message'] = 'Help message for edit button.';
+$string['edit_button_help_message_desc'] = 'Adds a text under the edit button.';

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,43 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Display checklist via filter
+ *
+ * @package    filter_checklist
+ * @copyright  2022 onwards Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+if ($ADMIN->fulltree) {
+
+    $settings->add(new admin_setting_configcheckbox(
+        'filter_checklist/edit_checklist_from_filter',
+        new lang_string('edit_checklist_from_filter', 'filter_checklist'),
+        new lang_string('edit_checklist_from_filter_desc', 'filter_checklist'),
+        0)
+    );
+
+    $settings->add(new admin_setting_configtextarea(
+        'filter_checklist/edit_button_help_message',
+        new lang_string('edit_button_help_message', 'filter_checklist'),
+        new lang_string('edit_button_help_message_desc', 'filter_checklist'),
+        '')
+    );
+}

--- a/styles.css
+++ b/styles.css
@@ -31,3 +31,7 @@
     margin: 1rem 0 0 0;
     padding-left: 0;
 }
+
+#filter_checklist > * {
+    margin-top: 1rem;
+}


### PR DESCRIPTION
This commits adds a button and a help text at the bottom of the embedded checklist for users with the right capability. Clicking on the button opens the checklist edit form.

If this PR is suitable, I would add before getting it merged:
- an admin setting to enable/disable the feature
- an admin setting to enable and set the help text (instead of the current lang string).

Let me know what you think about it.